### PR TITLE
Add support for Android constant string values

### DIFF
--- a/android/src/main/java/com/oversketch/open_app_settings/OpenAppSettingsPlugin.java
+++ b/android/src/main/java/com/oversketch/open_app_settings/OpenAppSettingsPlugin.java
@@ -121,8 +121,9 @@ public class OpenAppSettingsPlugin implements ActivityAware, FlutterPlugin, Meth
             openSettings(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
         } else if (call.method.equals("app_settings")) {
             openAppSettings();
-        } else {
-			openSettings(call.method);
+        } else if (call.method.equals("android")) {
+			if(call.hasArgument("setting"))
+				openSettings((String) call.argument("setting"));
 		}
     }
 

--- a/android/src/main/java/com/oversketch/open_app_settings/OpenAppSettingsPlugin.java
+++ b/android/src/main/java/com/oversketch/open_app_settings/OpenAppSettingsPlugin.java
@@ -121,7 +121,9 @@ public class OpenAppSettingsPlugin implements ActivityAware, FlutterPlugin, Meth
             openSettings(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
         } else if (call.method.equals("app_settings")) {
             openAppSettings();
-        }
+        } else {
+			openSettings(call.method);
+		}
     }
 
     @Override

--- a/lib/open_app_settings.dart
+++ b/lib/open_app_settings.dart
@@ -45,6 +45,9 @@ class OpenAppSettings {
   /// Future async method call to open app specific settings screen.
   static Future<void> openAppSettings() async => _to('app_settings');
 
+  /// Future async method call to open app specific settings screen.
+  static Future<void> openAndroidCustomSetting(String constantValue) async => _to(constantValue);
+
   /// Future async method call to open NCF settings.
   static Future<void> openNFCSettings() async => _to('nfc');
 

--- a/lib/open_app_settings.dart
+++ b/lib/open_app_settings.dart
@@ -46,10 +46,10 @@ class OpenAppSettings {
   static Future<void> openAppSettings() async => _to('app_settings');
 
   /// Future async method call to open app specific settings screen.
-  static Future<void> openAndroidCustomSetting(String constantValue) async => _to(constantValue);
+  static Future<void> openAndroidCustomSetting(String constantValue) async => _to("android", args: {"setting": constantValue});
 
   /// Future async method call to open NCF settings.
   static Future<void> openNFCSettings() async => _to('nfc');
 
-  static _to(String tag) => _channel.invokeMethod(tag);
+  static _to(String tag, {Map<String, String>? args}) => _channel.invokeMethod(tag, args ?? {});
 }


### PR DESCRIPTION
Adds a new method: **OpenAppSettings._openAndroidCustomSetting(String constantSettingValue)_**. It supports any setting constant string value from https://developer.android.com/reference/android/provider/Settings

I needed this for my shortcut manager app which allows user to add shortcuts to many locations, including those that don't have dedicated methods implemented in this package